### PR TITLE
Fixed Lambda Log Level and Introduced Log Group for ECS Task Def

### DIFF
--- a/backend/stateless/lambda/delete_entries/delete_entries.py
+++ b/backend/stateless/lambda/delete_entries/delete_entries.py
@@ -9,7 +9,8 @@ table = get_table(logger)
 
 
 def handler(event, context):
-    logger.info(event, context)
+    logger.info(f"Event: {event}")
+    logger.info(f"Context: {context}")
 
     body = json.loads(event["body"])
     id = body["Id"]

--- a/backend/stateless/lambda/get_entries/get_entries.py
+++ b/backend/stateless/lambda/get_entries/get_entries.py
@@ -9,6 +9,9 @@ table = get_table(logger)
 
 
 def handler(event, context):
+    logger.info(f"Event: {event}")
+    logger.info(f"Context: {context}")
+
     entries = []
 
     try:
@@ -16,13 +19,18 @@ def handler(event, context):
 
         done = False
         start_key = None
+
         while not done:
             if start_key:
                 scan_kwargs["ExclusiveStartKey"] = start_key
             response = table.scan(**scan_kwargs)
+            logger.info(f"Response page: {response}")
+
             entries.extend(response.get("Items", []))
+
             start_key = response.get("LastEvaluatedKey", None)
             done = start_key is None
+
     except ClientError as err:
         logger.error(
             "Failed when scanning for entries due to: %s: %s",

--- a/backend/stateless/lambda/upsert_entries/upsert_entries.py
+++ b/backend/stateless/lambda/upsert_entries/upsert_entries.py
@@ -10,7 +10,8 @@ table = get_table(logger)
 
 
 def handler(event, context):
-    logger.info(event, context)
+    logger.info(f"Event: {event}")
+    logger.info(f"Context: {context}")
 
     entry = json.loads(event["body"])
 

--- a/backend/stateless/stateless_stack.py
+++ b/backend/stateless/stateless_stack.py
@@ -97,6 +97,7 @@ class StatelessStack(Stack):
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PRIVATE_ISOLATED
             ),
+            log_format="JSON",
         )
         entries_table.grant(
             get_entries_function, "dynamodb:DescribeTable", "dynamodb:Scan"
@@ -116,6 +117,7 @@ class StatelessStack(Stack):
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PRIVATE_ISOLATED
             ),
+            log_format="JSON",
         )
         entries_table.grant(
             upsert_entries_function,
@@ -137,6 +139,7 @@ class StatelessStack(Stack):
             vpc_subnets=ec2.SubnetSelection(
                 subnet_type=ec2.SubnetType.PRIVATE_ISOLATED
             ),
+            log_format="JSON",
         )
         entries_table.grant(
             delete_entries_function, "dynamodb:DescribeTable", "dynamodb:DeleteItem"

--- a/backend/web/web_stack.py
+++ b/backend/web/web_stack.py
@@ -112,7 +112,6 @@ class WebStack(Stack):
             environment={"TODO_API_ENDPOINT": api.url},
             memory_limit_mib=512,
             cpu=256,
-            # https://stackoverflow.com/questions/55702196/essential-container-in-task-exited
             logging=ecs.AwsLogDriver(stream_prefix=prefix, log_group=log_group),
             port_mappings=[
                 # Next.js uses port 3000 by default, we'll adhere to that.

--- a/backend/web/web_stack.py
+++ b/backend/web/web_stack.py
@@ -152,10 +152,11 @@ class WebStack(Stack):
 
         # Define the "green" target group and listener that our ALB will use to route canary
         # traffic.
+        # We'll omit a target group name to prevent confusion once the target groups have been
+        # switched over in the ALB.
         green_target_group = elb.ApplicationTargetGroup(
             self,
             f"{prefix}GreenTargetGroup",
-            target_group_name=f"{prefix}GreenTG",
             protocol=elb.ApplicationProtocol.HTTP,
             target_type=elb.TargetType.IP,
             vpc=vpc,

--- a/pipeline/pipeline_stack.py
+++ b/pipeline/pipeline_stack.py
@@ -24,7 +24,7 @@ class PipelineStack(Stack):
                 input=pipelines.CodePipelineSource.git_hub(
                     # TODO move these into environment variables
                     "sendelivery/serverless-todo",
-                    "main",
+                    "fix/logging",
                 ),
                 commands=[
                     "chmod a+x ./scripts/pipeline/synth",

--- a/pipeline/pipeline_stack.py
+++ b/pipeline/pipeline_stack.py
@@ -114,7 +114,9 @@ class PipelineStack(Stack):
                     f"{prefix}FargateTaskExecutionRole "
                     f"{prefix}FargateTaskDefinition "
                     f"{prefix}ApiEndpoint "
-                    f"{ecr_repo_uri}:latest"
+                    f"{ecr_repo_uri}:latest "
+                    f"{prefix}WebContainers "
+                    f"{prefix}"
                 ),
             ],
         )

--- a/scripts/codedeploy/configure_deploy_step
+++ b/scripts/codedeploy/configure_deploy_step
@@ -27,6 +27,8 @@ task_execution_role_name=$5
 task_definition_name=$6
 api_endpoint_ssm_param=$7
 image_uri=$8
+log_group=$9
+stream_prefix=${10}
 
 echo "Pipeline Id:" "$pipeline_id"
 echo "Account:" "$account"
@@ -36,9 +38,11 @@ echo "Task Execution Role Name:" "$task_execution_role_name"
 echo "Task Definition Name:" "$task_definition_name"
 echo "API Endpoint SSM Param Name:" "$api_endpoint_ssm_param"
 echo "Image URI:" "$image_uri"
+echo "Log Group:" "$log_group"
+echo "Stream Prefix:" "$stream_prefix"
 
 TodoApiEndpoint="$(aws ssm get-parameter --name "$api_endpoint_ssm_param" --query Parameter.Value)" || exit
-TodoApiEndpoint=$(echo "$TodoApiEndpoint" | tr -d '"') # Remove double quotes
+TodoApiEndpoint=$(echo "$TodoApiEndpoint" | tr -d '"') # Removes double quotes
 
 echo "TodoApiEndpoint:" "$TodoApiEndpoint"
 
@@ -54,6 +58,7 @@ sed 's#CONTAINER_NAME#'"$container_name"'#g' codedeploy/template-appspec.yaml >c
 sed 's#CONTAINER_NAME#'"$container_name"'#g' codedeploy/template-taskdef.json |
   sed 's#TASK_EXEC_ROLE#arn:aws:iam::'"$account"':role/'"$task_execution_role_name"'#g' |
   sed 's#REGION#'"$region"'#g' | sed 's#TASK_DEF#'"$task_definition_name"'#g' |
+  sed 's#LOG_GROUP#'"$log_group"'#g' | sed 's#STREAM_PREFIX#'"$stream_prefix"'#g' |
   sed 's#TODO_API_ENDPOINT_VALUE#'"$TodoApiEndpoint"'#g' >codedeploy/taskdef.json
 
 cat codedeploy/appspec.yaml

--- a/scripts/codedeploy/template-taskdef.json
+++ b/scripts/codedeploy/template-taskdef.json
@@ -21,7 +21,6 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-create-group": "false",
           "awslogs-group": "LOG_GROUP",
           "awslogs-region": "REGION",
           "awslogs-stream-prefix": "STREAM_PREFIX"

--- a/scripts/codedeploy/template-taskdef.json
+++ b/scripts/codedeploy/template-taskdef.json
@@ -21,8 +21,8 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-create-group": "true",
-          "awslogs-group": "APPLICATION-ECS",
+          "awslogs-create-group": "false",
+          "awslogs-group": "LOG_GROUP",
           "awslogs-region": "REGION",
           "awslogs-stream-prefix": "STREAM_PREFIX"
         }


### PR DESCRIPTION
Fixed issue with Lambda logging where `INFO` level logs were not being shipped to CloudWatch by updating log formatting to use `JSON` format, which by default ships `INFO` logs.
[Source](https://docs.aws.amazon.com/lambda/latest/dg/python-logging.html)

Introduced a `...WebContainers` log group used in Fargate task definitions. This also works for the containers spun up by the Blue/Green deployment pipeline job.