### PR TITLE
Fixed Caching Bug Related to Statically Rendered Homepage

### DIFF
--- a/backend/networking/networking_stack.py
+++ b/backend/networking/networking_stack.py
@@ -70,6 +70,7 @@ class NetworkingStack(Stack):
             "Allow TCP from anywhere.",
         )
 
+        self._vpc_interface_endpoint = None
         if not ephemeral_deployment:
             # This VPC interface endpoint will be used to secure our REST API and simulatneously allow
             # the web app that will be deployed in our public subnets to access the private REST API.

--- a/backend/networking/networking_stack.py
+++ b/backend/networking/networking_stack.py
@@ -70,10 +70,14 @@ class NetworkingStack(Stack):
             "Allow TCP from anywhere.",
         )
 
-        self._vpc_interface_endpoint = None
-        if not ephemeral_deployment:
-            # This VPC interface endpoint will be used to secure our REST API and simulatneously allow
-            # the web app that will be deployed in our public subnets to access the private REST API.
+        if ephemeral_deployment:
+            # Our VPC doesn't need an interface endpoint if we're in an ephemeral environment,
+            # for simplicity, we'll expose our API GW endpoint to the open internet.
+            self._vpc_interface_endpoint = None
+        else:
+            # This VPC interface endpoint will be used to secure our REST API and simulatneously
+            # allow the web app that will be deployed in our public subnets to access the private
+            # REST API.
             self._vpc_interface_endpoint = self._vpc.add_interface_endpoint(
                 f"{prefix}VpcInterfaceEndpointForApi",
                 service=ec2.InterfaceVpcEndpointAwsService.APIGATEWAY,

--- a/backend/stateful/stateful_stack.py
+++ b/backend/stateful/stateful_stack.py
@@ -7,7 +7,7 @@ from aws_cdk import (
 from constructs import Construct
 
 
-# The stateful side of our application consists of a single DynamoDB table.
+# The stateful side of our application consists of a single DynamoDB table and ECR repository.
 
 
 class StatefulStack(Stack):
@@ -53,7 +53,7 @@ class StatefulStack(Stack):
                 )
             ]
 
-        repository_name = f"{prefix.lower()}web-container"
+        repository_name = f"{prefix.lower()}-web-container"
 
         self._ecr_repository = ecr.Repository(
             self,

--- a/backend/stateful/stateful_stack.py
+++ b/backend/stateful/stateful_stack.py
@@ -53,7 +53,7 @@ class StatefulStack(Stack):
                 )
             ]
 
-        repository_name = f"{prefix.lower()}-web-container"
+        repository_name = f"{prefix.lower()}web-container"
 
         self._ecr_repository = ecr.Repository(
             self,

--- a/backend/stateless/stateless_stack.py
+++ b/backend/stateless/stateless_stack.py
@@ -29,6 +29,7 @@ class StatelessStack(Stack):
         entries_table: ITable,
         vpc: IVpc,
         vpc_endpoint: IVpcEndpoint,
+        ephemeral_deployment: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -57,16 +58,22 @@ class StatelessStack(Stack):
             ]
         )
 
+        endpoint_configuration = apigw.EndpointConfiguration(
+            types=[apigw.EndpointType.PRIVATE],
+            vpc_endpoints=[vpc_endpoint],
+        )
+
+        if ephemeral_deployment:
+            endpoint_configuration = None
+            api_resource_policy = None
+
         # Define the REST API - deploy "prod" by default
         self._api = apigw.RestApi(
             self,
             f"{prefix}ApiDeploymentStage",
             rest_api_name=f"{prefix}Api",
             deploy=True,
-            endpoint_configuration=apigw.EndpointConfiguration(
-                types=[apigw.EndpointType.PRIVATE],
-                vpc_endpoints=[vpc_endpoint],
-            ),
+            endpoint_configuration=endpoint_configuration,
             policy=api_resource_policy,
         )
         entries_resource = self._api.root.add_resource("entries")

--- a/backend/stateless/stateless_stack.py
+++ b/backend/stateless/stateless_stack.py
@@ -34,12 +34,13 @@ class StatelessStack(Stack):
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        endpoint_configuration = None
-        api_resource_policy = None
-
         # Resource policy for our private API, this will restrict our API so that it can only be
-        # invoked via the designated VPC endpoint.
-        if not ephemeral_deployment:
+        # invoked via the designated VPC endpoint We don't configure this in ephemeral environments
+        # for simplicity.
+        if ephemeral_deployment:
+            api_resource_policy = None
+            endpoint_configuration = None
+        else:
             api_resource_policy = iam.PolicyDocument(
                 statements=[
                     iam.PolicyStatement(
@@ -73,8 +74,8 @@ class StatelessStack(Stack):
             f"{prefix}ApiDeploymentStage",
             rest_api_name=f"{prefix}Api",
             deploy=True,
-            endpoint_configuration=endpoint_configuration,
             policy=api_resource_policy,
+            endpoint_configuration=endpoint_configuration,
         )
         entries_resource = self._api.root.add_resource("entries")
 

--- a/backend/web/web_stack.py
+++ b/backend/web/web_stack.py
@@ -150,7 +150,9 @@ class WebStack(Stack):
         )
 
         fargate_service.target_group.configure_health_check(
-            healthy_http_codes="200", path="/health"
+            healthy_http_codes="200",
+            path="/health",
+            interval=Duration.minutes(5),
         )
 
         # From here on, we'll define the resources required for the Blue / Green deployment
@@ -175,7 +177,11 @@ class WebStack(Stack):
             f"{prefix}GreenTargetGroup",
             protocol=elb.ApplicationProtocol.HTTP,
             target_type=elb.TargetType.IP,
-            health_check=elb.HealthCheck(healthy_http_codes="200", path="/health"),
+            health_check=elb.HealthCheck(
+                healthy_http_codes="200",
+                path="/health",
+                interval=Duration.minutes(5),
+            ),
             vpc=vpc,
         )
 

--- a/backend/web/web_stack.py
+++ b/backend/web/web_stack.py
@@ -149,6 +149,10 @@ class WebStack(Stack):
             deployment_controller=deployment_controller,
         )
 
+        fargate_service.target_group.configure_health_check(
+            healthy_http_codes="200", path="/health"
+        )
+
         # From here on, we'll define the resources required for the Blue / Green deployment
         # strategy.
         # TODO move this out into a custom construct?
@@ -171,6 +175,7 @@ class WebStack(Stack):
             f"{prefix}GreenTargetGroup",
             protocol=elb.ApplicationProtocol.HTTP,
             target_type=elb.TargetType.IP,
+            health_check=elb.HealthCheck(healthy_http_codes="200", path="/health"),
             vpc=vpc,
         )
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -11,3 +11,11 @@
 - https://aws.amazon.com/blogs/devops/blue-green-deployments-using-aws-cdk-pipelines-and-aws-codedeploy/ | Blue / Green deployments using CDK Pipelines and CodeDeploy 🐐
 - https://blog.serverlessadvocate.com/serverless-aws-cdk-pipeline-best-practices-patterns-part-1-ab80962f109d | Lee Gilmore - Serverless CDK Pipeline best practices and patterns 🐐
 - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/create-task-definition.html | Sample ECS task definition
+- https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html | Fargate Task Def Logs
+- https://nextjs.org/learn/dashboard-app/static-and-dynamic-rendering#making-the-dashboard-dynamic | Caching bug
+- https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config | Caching bug
+
+////// potentially read later?
+
+https://blog.serverlessadvocate.com/serverless-threat-modelling-df8e4028ef6d
+https://levelup.gitconnected.com/serverless-event-driven-systems-9617c6406064

--- a/pipeline/application_stage.py
+++ b/pipeline/application_stage.py
@@ -26,12 +26,15 @@ class ApplicationStage(Stage):
     ):
         super().__init__(scope, id, **kwargs)
 
+        ephemeral_deployment = self.node.try_get_context("ephemeral_prefix") is not None
+
         # The networking stack defines the VPC, subnets, and VPC endpoints that will be used
         # throughout.
         self._networking = NetworkingStack(
             self,
             f"{prefix}NetworkingStack",
             prefix=prefix,
+            ephemeral_deployment=ephemeral_deployment,
         )
 
         # The stateful stack defines our application's storage tier. In this case, just a DynamoDB
@@ -52,6 +55,7 @@ class ApplicationStage(Stage):
             entries_table=self.stateful_stack.entries_table,
             vpc=self._networking.vpc,
             vpc_endpoint=self._networking.vpc_interface_endpoint,
+            ephemeral_deployment=ephemeral_deployment,
             **kwargs,
         )
 
@@ -65,5 +69,6 @@ class ApplicationStage(Stage):
             api=self._stateless.api,
             vpc=self._networking.vpc,
             ecr_repo=self._stateful.ecr_repository,
+            ephemeral_deployment=ephemeral_deployment,
             **kwargs,
         )

--- a/pipeline/pipeline_stack.py
+++ b/pipeline/pipeline_stack.py
@@ -24,7 +24,7 @@ class PipelineStack(Stack):
                 input=pipelines.CodePipelineSource.git_hub(
                     # TODO move these into environment variables
                     "sendelivery/serverless-todo",
-                    "fix/cache-invalidation",
+                    "main",
                 ),
                 commands=[
                     "chmod a+x ./scripts/pipeline/synth",
@@ -44,7 +44,7 @@ class PipelineStack(Stack):
         # construct here as it doesn't exist when the pipeline is synthesized and thus would be
         # considered "crossing stage boundaries". However, the name, URI, and ARN can be
         # consistently determined using information we have.
-        ecr_repo_name = f"{prefix.lower()}web-container"
+        ecr_repo_name = f"{prefix.lower()}-web-container"
         ecr_repo_uri = (
             f"{self.account}.dkr.ecr.{self.region}.amazonaws.com/{ecr_repo_name}"
         )

--- a/pipeline/pipeline_stack.py
+++ b/pipeline/pipeline_stack.py
@@ -24,7 +24,7 @@ class PipelineStack(Stack):
                 input=pipelines.CodePipelineSource.git_hub(
                     # TODO move these into environment variables
                     "sendelivery/serverless-todo",
-                    "fix/logging",
+                    "fix/cache-invalidation",
                 ),
                 commands=[
                     "chmod a+x ./scripts/pipeline/synth",

--- a/pipeline/pipeline_stack.py
+++ b/pipeline/pipeline_stack.py
@@ -44,7 +44,7 @@ class PipelineStack(Stack):
         # construct here as it doesn't exist when the pipeline is synthesized and thus would be
         # considered "crossing stage boundaries". However, the name, URI, and ARN can be
         # consistently determined using information we have.
-        ecr_repo_name = f"{prefix.lower()}-web-container"
+        ecr_repo_name = f"{prefix.lower()}web-container"
         ecr_repo_uri = (
             f"{self.account}.dkr.ecr.{self.region}.amazonaws.com/{ecr_repo_name}"
         )

--- a/pipeline/pipeline_stack.py
+++ b/pipeline/pipeline_stack.py
@@ -59,9 +59,16 @@ class PipelineStack(Stack):
             f"{prefix}BuildAndUploadDockerImage",
             commands=[
                 "chmod a+x ./scripts/pipeline/push_to_ecr",
-                f"./scripts/pipeline/push_to_ecr {ecr_repo_uri}",
+                f"./scripts/pipeline/push_to_ecr {ecr_repo_uri} {prefix}ApiEndpoint",
             ],
             role_policy_statements=[
+                iam.PolicyStatement(
+                    actions=["ssm:GetParameter"],
+                    resources=[
+                        f"arn:aws:ssm:{self.region}:{self.account}:parameter/{prefix}ApiEndpoint",
+                    ],
+                    effect=iam.Effect.ALLOW,
+                ),
                 iam.PolicyStatement(
                     actions=[
                         "ecr:CompleteLayerUpload",
@@ -160,11 +167,8 @@ class PipelineStack(Stack):
             application,
             stack_steps=[
                 pipelines.StackSteps(
-                    stack=application.stateful_stack,
-                    post=[build_and_deploy_docker_image_step],
-                ),
-                pipelines.StackSteps(
                     stack=application.web_stack,
+                    pre=[build_and_deploy_docker_image_step],
                     post=[configure_deploy_step, deploy_step],
                 ),
             ],

--- a/scripts/deploy_ephemeral
+++ b/scripts/deploy_ephemeral
@@ -48,7 +48,7 @@ clean_string() {
 }
 
 PREFIX=$(clean_string "$branch_name")
-PREFIX="${PREFIX:0:24}-"
+PREFIX="${PREFIX:0:25}"
 readonly PREFIX
 
 echo -e "Using prefix: ${CYAN}$PREFIX${NO_COLOUR}"

--- a/scripts/pipeline/push_to_ecr
+++ b/scripts/pipeline/push_to_ecr
@@ -8,10 +8,19 @@
 #
 
 repo=$1
+api_endpoint_ssm_param=$2
 
-echo "ECR Repository: "$repo
+echo "ECR Repository: " "$repo"
+echo "API Endpoint SSM Param Name:" "$api_endpoint_ssm_param"
+
+TodoApiEndpoint="$(aws ssm get-parameter --name "$api_endpoint_ssm_param" --query Parameter.Value)" || exit
+TodoApiEndpoint=$(echo "$TodoApiEndpoint" | tr -d '"') # Removes double quotes
+
+echo "API Endpoint:" "$TodoApiEndpoint"
 
 cd web/ || exit
+
+echo "TODO_API_ENDPOINT=""$TodoApiEndpoint" >.env.local
 
 echo Logging in to Amazon ECR
 aws ecr get-login-password | docker login --username AWS --password-stdin "$repo"

--- a/scripts/pipeline/push_to_ecr
+++ b/scripts/pipeline/push_to_ecr
@@ -11,6 +11,7 @@ repo=$1
 api_endpoint_ssm_param=$2
 
 echo "ECR Repository: " "$repo"
+# TODO - do we need this now that our root page is dynamically rendered?
 echo "API Endpoint SSM Param Name:" "$api_endpoint_ssm_param"
 
 TodoApiEndpoint="$(aws ssm get-parameter --name "$api_endpoint_ssm_param" --query Parameter.Value)" || exit

--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["next", "next/core-web-vitals", "prettier"]
+  "extends": ["next/babel", "next/core-web-vitals", "prettier"]
 }

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS base
+FROM --platform=linux/amd64 node:18-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/web/app/actions.ts
+++ b/web/app/actions.ts
@@ -45,7 +45,7 @@ export async function serverPostEntry(formData: FormData) {
     console.error({
       message: "Received a non 2XX response when creating new todo entry.",
       input: JSON.stringify(todoEntryInput),
-      response: JSON.stringify(response),
+      response,
     });
     throw new Error("Unable to create new todo entry. Please try again later.");
   }
@@ -81,7 +81,7 @@ export async function serverPutEntry(id: string, completed: boolean) {
     console.error({
       message: "Received a non 2XX response when updating a todo entry.",
       proposedUpdate,
-      response: JSON.stringify(response),
+      response,
     });
     throw new Error("Unable to update todo entry. Please try again later.");
   }
@@ -108,7 +108,7 @@ export async function serverDeleteEntry(id: string) {
     console.error({
       message: "Received a non 2XX response when deleting a todo entry.",
       id,
-      response: JSON.stringify(response),
+      response,
     });
     throw new Error("Unable to delete todo entry. Please try again later.");
   }

--- a/web/app/health/page.tsx
+++ b/web/app/health/page.tsx
@@ -3,7 +3,7 @@ import utilStyles from "@/styles/utilities.css";
 export default function Page() {
   return (
     <h1 className={`${utilStyles.headingXl} ${utilStyles.centredText}`}>
-      🎊 All systems <span className={utilStyles.highlightedText}>GO!</span> 🎊
+      All systems <span className={utilStyles.highlightedText}>GO!</span>
     </h1>
   );
 }

--- a/web/app/health/page.tsx
+++ b/web/app/health/page.tsx
@@ -1,0 +1,9 @@
+import utilStyles from "@/styles/utilities.css";
+
+export default function Page() {
+  return (
+    <h1 className={`${utilStyles.headingXl} ${utilStyles.centredText}`}>
+      🎊 All systems <span className={utilStyles.highlightedText}>GO!</span> 🎊
+    </h1>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -13,7 +13,11 @@ export default async function Page() {
       },
     });
 
+    console.log({ response });
+
     entries = await response.json();
+
+    console.log({ entries });
   } else {
     console.warn(
       "API endpoint and or key are undefined, please ensure environment variables are correctly set."

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -9,8 +9,7 @@ export default async function Page() {
   if (todoApiEndpoint) {
     const response = await fetch(todoApiEndpoint, {
       next: {
-        // tags: [ENTRIES_CACHE_TAG],
-        revalidate: 0,
+        tags: [ENTRIES_CACHE_TAG],
       },
     });
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -3,6 +3,8 @@ import { type TodoEntry } from "@/lib/types";
 import ToastQueueProvider from "@/components/ToastQueueProvider";
 import TodoSection from "@/components/TodoSection";
 
+export const dynamic = "force-dynamic";
+
 export default async function Page() {
   let entries: TodoEntry[] = [];
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -7,17 +7,20 @@ export default async function Page() {
   let entries: TodoEntry[] = [];
 
   if (todoApiEndpoint) {
-    const response = await fetch(todoApiEndpoint, {
-      next: {
-        tags: [ENTRIES_CACHE_TAG],
-      },
-    });
+    try {
+      const response = await fetch(todoApiEndpoint, {
+        next: {
+          tags: [ENTRIES_CACHE_TAG],
+        },
+      });
 
-    console.log({ response });
+      console.log({ response });
 
-    entries = await response.json();
-
-    console.log({ entries });
+      entries = await response.json();
+      console.log({ entries });
+    } catch (error) {
+      console.error(error);
+    }
   } else {
     console.warn(
       "API endpoint and or key are undefined, please ensure environment variables are correctly set."

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -15,17 +15,18 @@ export default async function Page() {
           tags: [ENTRIES_CACHE_TAG],
         },
       });
-
-      console.log({ response });
+      console.debug({ response });
 
       entries = await response.json();
-      console.log({ entries });
+      console.log({ message: "Successfully fetched entries!", entries });
     } catch (error) {
-      console.error(error);
+      console.error({
+        message: `Failed to fetch entries with the following error: ${error}`,
+      });
     }
   } else {
     console.warn(
-      "API endpoint and or key are undefined, please ensure environment variables are correctly set."
+      "API endpoint is undefined, please ensure environment variables are correctly set."
     );
   }
 

--- a/web/components/TodoSection/index.tsx
+++ b/web/components/TodoSection/index.tsx
@@ -51,7 +51,7 @@ export default function TodoSection(props: TodoSectionProps) {
         enqueueToast({
           level: "error",
           message:
-            "Sorry, we had trouble creating your Todo entry, please try again later.",
+            "Sorry, we had trouble creating your todo entry, please try again later.",
           lifespan: "inf",
         });
       });
@@ -76,7 +76,7 @@ export default function TodoSection(props: TodoSectionProps) {
         enqueueToast({
           level: "error",
           message:
-            "Sorry, we had trouble updating your Todo entry, please try again later.",
+            "Sorry, we had trouble updating your todo entry, please try again later.",
           lifespan: "inf",
         });
       });
@@ -97,7 +97,7 @@ export default function TodoSection(props: TodoSectionProps) {
         enqueueToast({
           level: "error",
           message:
-            "Sorry, we had trouble deleting your Todo entry, please try again later.",
+            "Sorry, we had trouble deleting your todo entry, please try again later.",
           lifespan: "inf",
         });
       });

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const { createVanillaExtractPlugin } = require("@vanilla-extract/next-plugin");
 const withVanillaExtract = createVanillaExtractPlugin();
 

--- a/web/package.json
+++ b/web/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:docker": "docker build -t web-app .",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
Fixed a bug where the homepage was not fetching todo entries upon initial load or reloads due to it being statically rendered at build time, before the API endpoint existed. Hence setting the entries initial state to always be an empty array.

The root page is now dynamically rendered on the server, i.e. at request time. Correctly fetching and caching the todo entries!

Also:
- Introduced a health page and configured health checks to ping `/health` every 5 minutes. Previously, health checks would trigger a full DB scan every 30 seconds when pinging the `/` route!
- Improved ephemeral stack configuration by conditionally setting certain values.

Future work:
- Refactor magic strings / values into a global, or _stack scoped_ configuration file for easier tweaking.
- Confirm accuracy of code comments.
- Bring project documentation up to date.